### PR TITLE
Temporary fix to render something without routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4163,6 +4163,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
     },
+    "mousetrap": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.1.tgz",
+      "integrity": "sha1-KghfXHUSlMdefoH27CVFspy/Qtk="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "fs": "0.0.1-security",
     "jest-cli": "^20.0.4",
     "jquery": "^3.2.1",
+    "mousetrap": "^1.6.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "semantic-ui-react": "^0.68.5"

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import { Input } from "semantic-ui-react";
 import Login from "../Login/Login";
 import "./App.css";
 
@@ -12,17 +11,24 @@ class App extends Component {
 
 	handleToken(token) {
 		this.setState({
-		 	token: token
-		 }); 
-		console.log(this.state.token);
+			token: token
+		});
 	}
 
 	render() {
-		return (
-			<div className="App">
-				<Login token={this.handleToken} />
-			</div>
-		);
+		if (!this.state.token) {
+			return (
+				<div className="App">
+					<Login token={this.handleToken} />
+				</div>
+			);
+		} else {
+			return (
+				<div>
+					<h1>Yay! I've logged in!</h1>
+				</div>
+			);
+		}
 	}
 }
 

--- a/src/Components/Login/Login.js
+++ b/src/Components/Login/Login.js
@@ -1,10 +1,8 @@
 import React from "react";
-import ReactDom from "react-dom";
-import "../../libs/semantic-ui/semantic.min.css"
+import "../../libs/semantic-ui/semantic.min.css";
 import "./Login.css";
 import { Input } from "semantic-ui-react";
 import { Button } from "semantic-ui-react";
-import { Form } from "semantic-ui-react";
 import $ from "jquery";
 
 export default class Login extends React.Component {
@@ -17,6 +15,7 @@ export default class Login extends React.Component {
 		this.postUser = this.postUser.bind(this);
 		this.state = { username: "", password: "" };
 	}
+
 
 	// Render function : to render our component
 	render() {
@@ -63,7 +62,10 @@ export default class Login extends React.Component {
 							as I said earlier, will post a request to the server. Server will then send a token, which is to be used for any
 							further requests in a session.
 							*/}
-							<Button type="submit" onClick={this.handleSubmit}>
+							<Button
+								type="submit"
+								onClick={this.handleSubmit}
+							>
 								LOGIN
 							</Button>
 
@@ -119,7 +121,7 @@ export default class Login extends React.Component {
 				responseBox.addClass("Response-active");
 				if (err.status === 404) {
 					// If the username is wrong
-					let responseMessage = `Please check if the username you entered is correct and try again.`;
+					let responseMessage = `Username you just entered is incorrect. Try again please.`;
 					responseBox.children().text(responseMessage).fadeIn(300);
 				}
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./Components/App/App";
-import "./libs/semantic-ui/semantic.min.css"
 
 import registerServiceWorker from "./registerServiceWorker";
 


### PR DESCRIPTION
App removes Login component when token it gets the token, and then renders something important, without changing the URL, i.e. without refreshing the page, resulting in super fast rendering.
A local storage session to remember the token after the user logs in is yet to be implemented.